### PR TITLE
Export reader and fix some errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde-xml-rs = "0.3"
+serde-xml-rs = "0.4"
 libflate = "0.1"
 zip = "0.5"

--- a/src/aggregate_report.rs
+++ b/src/aggregate_report.rs
@@ -5,7 +5,7 @@
 // had to make certain fields optional even though the spec says they are not.
 // Also had to make the version field a String.
 // Guess the spec is not being followed to a T.
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -84,7 +84,7 @@ pub struct PolicyEvaluatedType {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RowType {
-    pub source_ip:          Ipv4Addr,
+    pub source_ip:          IpAddr,
     pub count:              u32,
     pub policy_evaluated:   PolicyEvaluatedType
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn get_file_reader(path: &Path) -> Result<BufReader<File>, Box<std::error::Error
     Ok(BufReader::new(file))
 }
 
-fn parse_reader(reader: &mut Read) -> Result<aggregate_report::feedback, Box<std::error::Error>> {
+pub fn parse_reader(reader: &mut Read) -> Result<aggregate_report::feedback, Box<std::error::Error>> {
     match from_reader(reader) {
         Ok(result) => Ok(result),
         Err(error) => Err(error.into())


### PR DESCRIPTION
On a recent rust, the project doesn't compile anymore due to deprecation in serde-xml-rs. This PR fixes this issue by bumping the dependency.
It allows export the parse Reader to be able to provide a reader to the library when we already have data in memory.
The library wasn't supporting ipv6 in reports, it's now possible