### PR TITLE
Refactor:  parse Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea/**
+/sample-data/unreadable.xml

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -2,8 +2,11 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ParsingError {
-    #[error("Cannot open file")]
-    Io(#[from] std::io::Error),
+    #[error("Cannot open file: '{path}' {source}")]
+    Io {
+        source: std::io::Error,
+        path: String,
+    },
     #[error("Parsing error")]
     Parse(#[from] serde_xml_rs::Error),
     #[error("Error unpacking archive")]


### PR DESCRIPTION
Test Modules
  Break parse and parse_dir as seperate test modules.
  Refactor test:test_parse_single()

Rename to single_xml
  - Test Result.version is None
  - Test result.report_metadata.email is as expected.

Edit .gitignore file
  Ignore unreadable file. read bits unset

Refactor ParseingError for io::Error
  Add more information to the error message.  It now provides information on unreadable file or file does not exist.

Tests:
  Add additional tests.
  Add ignore for test that can not be included in git due to file being "unreadable"

Refactor Io Error to contain more details
  The Io Error now contains the Os Error information as well as the path of the file/directory that caused the failure.

Refactor Error for parse()
  Use map_err() to convert and IO Error to the ParsingError::Io containing the additional information. This will help show which directory or file failed to be parsed with the related error code and message.
