### PR TITLE
Documentation and Clippy

### DIFF
--- a/src/aggregate_report.rs
+++ b/src/aggregate_report.rs
@@ -28,15 +28,21 @@ pub struct ReportMetadataType {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum AlignmentType {
+    /// Relaxed
     r,
+    /// Strict
     s,
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum DispositionType {
+    /// There is no preference on how a failed DMARC should be handled.
     none,
+    /// The message should be quarantined. This usually means it will be placed in the `spam` folder
+    /// of the user
     quarantine,
+    /// The message should be regjected.
     reject,
 }
 
@@ -156,6 +162,7 @@ pub struct RecordType {
     pub auth_results: AuthResultType,
 }
 
+/// This struct contains all relevant information for a single DMARC Report
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct feedback {

--- a/src/aggregate_report.rs
+++ b/src/aggregate_report.rs
@@ -1,3 +1,4 @@
+//! Contains the required stuctures and enums used to store data from a parsed xml report.
 // Based upon appendix C of the DMARC RFC
 // https://tools.ietf.org/html/rfc7489#appendix-C
 
@@ -5,30 +6,30 @@
 // had to make certain fields optional even though the spec says they are not.
 // Also had to make the version field a String.
 // Guess the spec is not being followed to a T.
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
-use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DateRangeType {
-    pub begin:  u32,
-    pub end:    u32
+    pub begin: u32,
+    pub end: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReportMetadataType {
-    pub org_name:           String,
-    pub email:              String,
+    pub org_name: String,
+    pub email: String,
     pub extra_contact_info: Option<String>,
-    pub report_id:          String,
-    pub date_range:         DateRangeType,
-    pub error:              Option<Vec<String>>
+    pub report_id: String,
+    pub date_range: DateRangeType,
+    pub error: Option<Vec<String>>,
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum AlignmentType {
     r,
-    s
+    s,
 }
 
 #[allow(non_camel_case_types)]
@@ -36,25 +37,25 @@ pub enum AlignmentType {
 pub enum DispositionType {
     none,
     quarantine,
-    reject
+    reject,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PolicyPublishedType {
-    pub domain:     String,
-    pub adkim:      Option<AlignmentType>,
-    pub aspf:       Option<AlignmentType>,
-    pub p:          DispositionType,
-    pub sp:         Option<DispositionType>,
-    pub pct:        u8,
-    pub fo:         Option<String>
+    pub domain: String,
+    pub adkim: Option<AlignmentType>,
+    pub aspf: Option<AlignmentType>,
+    pub p: DispositionType,
+    pub sp: Option<DispositionType>,
+    pub pct: u8,
+    pub fo: Option<String>,
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum DMARCResultType {
     pass,
-    fail
+    fail,
 }
 
 #[allow(non_camel_case_types)]
@@ -65,35 +66,35 @@ pub enum PolicyOverrideType {
     trusted_forwarder,
     mailing_list,
     local_policy,
-    other
+    other,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PolicyOverrideReason {
-    pub r#type:     PolicyOverrideType,
-    pub comment:    Option<String>
+    pub r#type: PolicyOverrideType,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PolicyEvaluatedType {
-    pub disposition:    DispositionType,
-    pub dkim:           Option<DMARCResultType>,
-    pub spf:            Option<DMARCResultType>,
-    pub reason:         Option<Vec<PolicyOverrideReason>>
+    pub disposition: DispositionType,
+    pub dkim: Option<DMARCResultType>,
+    pub spf: Option<DMARCResultType>,
+    pub reason: Option<Vec<PolicyOverrideReason>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RowType {
-    pub source_ip:          IpAddr,
-    pub count:              u32,
-    pub policy_evaluated:   PolicyEvaluatedType
+    pub source_ip: IpAddr,
+    pub count: u32,
+    pub policy_evaluated: PolicyEvaluatedType,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IdentifierType {
-    pub envelope_to:    Option<String>,
-    pub envelope_from:  Option<String>,
-    pub header_from:    String
+    pub envelope_to: Option<String>,
+    pub envelope_from: Option<String>,
+    pub header_from: String,
 }
 
 #[allow(non_camel_case_types)]
@@ -105,22 +106,22 @@ pub enum DKIMResultType {
     policy,
     neutral,
     temperror,
-    permerror
+    permerror,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DKIMAuthResultType {
-    pub domain:         String,
-    pub selector:       Option<String>,
-    pub result:         DKIMResultType,
-    pub human_result:   Option<String>
+    pub domain: String,
+    pub selector: Option<String>,
+    pub result: DKIMResultType,
+    pub human_result: Option<String>,
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum SPFDomainScope {
     helo,
-    mfrom
+    mfrom,
 }
 
 #[allow(non_camel_case_types)]
@@ -132,34 +133,34 @@ pub enum SPFResultType {
     fail,
     softfail,
     temperror,
-    permerror
+    permerror,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SPFAuthResultType {
     pub domain: String,
-    pub scope:  Option<SPFDomainScope>,
-    pub result: SPFResultType
+    pub scope: Option<SPFDomainScope>,
+    pub result: SPFResultType,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AuthResultType {
-    pub dkim:   Option<Vec<DKIMAuthResultType>>,
-    pub spf:    Vec<SPFAuthResultType>
+    pub dkim: Option<Vec<DKIMAuthResultType>>,
+    pub spf: Vec<SPFAuthResultType>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RecordType {
-    pub row:            RowType,
-    pub identifiers:    IdentifierType,
-    pub auth_results:   AuthResultType
+    pub row: RowType,
+    pub identifiers: IdentifierType,
+    pub auth_results: AuthResultType,
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct feedback {
-    pub version:            Option<String>,
-    pub report_metadata:    ReportMetadataType,
-    pub policy_published:   PolicyPublishedType,
-    pub record:             Vec<RecordType>
+    pub version: Option<String>,
+    pub report_metadata: ReportMetadataType,
+    pub policy_published: PolicyPublishedType,
+    pub record: Vec<RecordType>,
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,18 +1,32 @@
+//! Provides the required error types that are expected to be possible while parsing a file.
 use thiserror::Error;
-
+/// An enumeration of possible errors that might occur during the parsing event
 #[derive(Error, Debug)]
 pub enum ParsingError {
+    /// If there is IO error this eorror will be reported
     #[error("Cannot open file: '{path}' {source}")]
     Io {
+        /// Original source error from std::io::Error
         source: std::io::Error,
+        /// The path of the file being parsed
         path: String,
     },
+    /// This error occurs when the xml file can not be parsed.
     #[error("Parsing error")]
     Parse(#[from] serde_xml_rs::Error),
+    /// Error when attempting to de-archive the file.
     #[error("Error unpacking archive")]
     Zip(#[from] zip::result::ZipError),
+    /// If the parser encounters an unexpected file
     #[error("Unexpected file with extension {extension:?})")]
-    UnknownFile { extension: std::string::String },
+    UnknownFile {
+        /// The file extension of the file being passed
+        extension: std::string::String,
+    },
+    /// the function [crate::parse()] has be passed a directory instead of file
     #[error("Cannot parse '{path_str}' as it is a directory. Use parse_dir()")]
-    ParseDirectory { path_str: std::string::String },
+    ParseDirectory {
+        /// The path of the directory that was passed to [crate::parse()]
+        path_str: std::string::String,
+    },
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 /// An enumeration of possible errors that might occur during the parsing event
 #[derive(Error, Debug)]
 pub enum ParsingError {
-    /// If there is IO error this eorror will be reported
+    /// If there is IO error this error will be returned
     #[error("Cannot open file: '{path}' {source}")]
     Io {
         /// Original source error from std::io::Error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
+#![forbid(unsafe_code)]
+/*#![warn(missing_docs)]*/
 #![deny(missing_debug_implementations)]
+
+//! The DMARC Aggregate Parser is intended to provide a programmatical way to access information in an DMARC report.
+
 pub mod aggregate_report;
 pub mod error_handling;
 use error_handling::ParsingError;
@@ -11,8 +16,20 @@ use std::io::Read;
 use std::path::Path;
 
 /// This function takes a reference to a file to be parsed. If the file can not be parsed a [ParsingError] is returned.
+/// #Example:
+/// ```rust
+/// use dmarc_aggregate_parser::parse;
+/// # let path = Path::new("./sample-data/dmarc.xml");
+/// let result = parse(path);
+/// assert!(result.is_ok(), true);
+/// if let Ok(result) = result {
+///     assert_eq!(result.unwrap().report_metadata.email,
+///                "postmaster@aol.com".to_string()
+///             );
+/// }
+/// ```
 /// # Errors
-/// ParsingError::ParseDirectory will occur is a directory is passed. Use [parse_dir()]
+/// ParsingError::ParseDirectory will occur is a directory is passed.
 pub fn parse<T: std::convert::AsRef<std::ffi::OsStr>>(
     path: T,
 ) -> Result<aggregate_report::feedback, ParsingError> {
@@ -80,7 +97,10 @@ fn parse_reader(reader: &mut dyn Read) -> Result<aggregate_report::feedback, Par
 
 /// This function takes a directory path as an argument. If no dmarc report are found, an empty `Vec` is returned.
 /// Any subdirectories are ignored.
-/// Any files that can not be parsed will be reported stderr
+/// Any files that can not be parsed will be reported through STDERR
+/// # Note: Not suitable for production level use.
+/// This function is only really suitable for testing. You are advised to use [parse()] within your own directory
+/// processing code. In this way you can manage files as you wish.
 pub fn parse_dir(path: &Path) -> Vec<aggregate_report::feedback> {
     let mut results = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,18 @@ use std::path::Path;
 /// #Example:
 /// ```rust
 /// use dmarc_aggregate_parser::parse;
+/// # use std::path::Path;
 /// # let path = Path::new("./sample-data/dmarc.xml");
 /// let result = parse(path);
 /// assert!(result.is_ok(), true);
 /// if let Ok(result) = result {
-///     assert_eq!(result.unwrap().report_metadata.email,
+///     assert_eq!(result.report_metadata.email,
 ///                "postmaster@aol.com".to_string()
 ///             );
 /// }
 /// ```
 /// # Errors
-/// ParsingError::ParseDirectory will occur is a directory is passed.
+/// See [ParsingError]
 pub fn parse<T: std::convert::AsRef<std::ffi::OsStr>>(
     path: T,
 ) -> Result<aggregate_report::feedback, ParsingError> {


### PR DESCRIPTION
- Add some basic documentation.
- Ran clippy and check against the code. This has generated formatting
  changes to ensure the code format is consistant with rust standards.
  These changes include adding commas at the end of lines and other
  minor changes.

There is a need for a lot of documentation. I have disabled the
[warn(missing_docs)] in the commit. But should be enabled while
documenting the code.
